### PR TITLE
Add minimal header and navigation styling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 3.9.3"
 gem "github-pages", "~> 228"
-gem "webrick", "~> 1.8" 
+gem "webrick", "~> 1.8"
+gem "csv", "~> 3.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
     commonmarker (0.23.11)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
+    csv (3.3.5)
     dnsruby (1.72.4)
       base64 (~> 0.2.0)
       logger (~> 1.6.5)
@@ -37,7 +38,8 @@ GEM
     execjs (2.10.0)
     faraday (2.0.0)
       ruby2_keywords (>= 0.0.4)
-    ffi (1.17.2)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (228)
@@ -221,9 +223,9 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.25.5)
     mutex_m (0.3.0)
-    nokogiri (1.15.7-arm64-darwin)
+    nokogiri (1.18.9-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.7-x86_64-linux)
+    nokogiri (1.18.9-x86_64-linux-gnu)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -264,6 +266,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  csv (~> 3.3)
   github-pages (~> 228)
   jekyll (~> 3.9.3)
   webrick (~> 1.8)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install serve build clean preview check-images
+.PHONY: install serve build clean preview check-images test
 
 # Install dependencies
 install:
@@ -56,5 +56,8 @@ fix-image-links:
 fix-image-links-apply:
 	python3 scripts/fix_markdown_image_links.py --apply
 
+# Run all checks
+test: build check-images
+
 # Default target
-all: install serve 
+all: install serve

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,9 @@
+<header class="site-header">
+  <div class="wrapper">
+    <a class="site-title" href="{{ site.baseurl }}/">{{ site.title }}</a>
+    <nav class="nav-links">
+      <a href="{{ site.baseurl }}/">Home</a>
+      <a href="https://github.com/andrewm4894" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </div>
+</header>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -67,17 +67,12 @@
         float: none;
         padding: 0;
       }
-      .wrapper {
-        width: auto;
-        margin: 0 auto;
-        padding: 0 20px;
-        max-width: 1200px;
-      }
     </style>
   </head>
   <body>
+    {% include header.html %}
     <div class="wrapper">
       {{ content }}
     </div>
   </body>
-</html> 
+</html>

--- a/_layouts/post_no_sidebar.html
+++ b/_layouts/post_no_sidebar.html
@@ -30,7 +30,8 @@
     
   </head>
   <body>
-    <div class="wrapper" style="display: flex; max-width: 1200px; margin: 0 auto; padding: 0 20px;">
+    {% include header.html %}
+    <div class="wrapper" style="display: flex;">
       <!-- Main content -->
       <section style="flex: 1; max-width: 800px; margin-right: 40px;">
         <div style="margin-bottom: 2em;">

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -6,6 +6,43 @@ body {
   color: #333;
 }
 
+.wrapper {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+.site-header {
+  background: #f5f7f9;
+  border-bottom: 1px solid #e1e4e8;
+  margin-bottom: 2rem;
+}
+
+.site-header .wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+}
+
+.site-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #333;
+  text-decoration: none;
+}
+
+.nav-links a {
+  margin-left: 1rem;
+  color: #333;
+  text-decoration: none;
+}
+
+.nav-links a:hover {
+  color: #267CB9;
+}
+
 h1, h2, h3, h4, h5, h6 {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- add shared header include with site title and GitHub link
- style header and layout containers for a cleaner minimal look
- introduce `test` target to Makefile and declare csv gem for builds

## Testing
- `bundle install`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68ae23cfd4188328980e65ab60d92082

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced a site-wide header with a clickable site title and navigation links (Home and GitHub opening in a new tab).

* Style
  * Added responsive layout wrapper and refined header styling (spacing, typography, hover states) for a cleaner, consistent look.

* Chores
  * Added CSV library dependency.
  * Introduced a “make test” command that runs build and image checks; corrected the default make target.
  * Minor formatting cleanups (end-of-file newlines).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->